### PR TITLE
check if base class does have a _meta attribute

### DIFF
--- a/cabinet/base.py
+++ b/cabinet/base.py
@@ -280,7 +280,7 @@ def determine_accept_file_functions(sender, **kwargs):
         fieldsets = []
 
         for cls in list(inspect.getmro(sender))[1:]:
-            if not hasattr(cls, "_meta"):
+            if not issubclass(cls, models.Model):
                 continue
             for f in fields:
                 try:

--- a/cabinet/base.py
+++ b/cabinet/base.py
@@ -280,6 +280,8 @@ def determine_accept_file_functions(sender, **kwargs):
         fieldsets = []
 
         for cls in list(inspect.getmro(sender))[1:]:
+            if not hasattr(cls, "_meta"):
+                continue
             for f in fields:
                 try:
                     cls._meta.get_field(f)

--- a/tests/testapp/test_cabinet.py
+++ b/tests/testapp/test_cabinet.py
@@ -15,6 +15,7 @@ from django.urls import reverse
 from testapp.models import Stuff
 
 from cabinet.models import File, Folder, get_file_model
+from cabinet.base import AbstractFile, ImageMixin, determine_accept_file_functions
 
 
 class CabinetTestCase(TestCase):
@@ -535,3 +536,12 @@ class CabinetTestCase(TestCase):
 
         f1 = File.objects.get()
         self.assertEqual(f1.image_file, "")
+
+    def test_custom_file(self):
+        class NonModelMixin:
+            pass
+
+        class CustomFile(AbstractFile, NonModelMixin, ImageMixin):
+            FILE_FIELDS = ['image_file']
+
+        determine_accept_file_functions(CustomFile)


### PR DESCRIPTION
I use django parlor in my project and tried to implement a custom translatable file. 

```
class File(AbstractFile, ImageMixin, OverwriteMixin, TranslatableModel):
    translations(...)
    ...
```

But django parler uses a TranslatableModelMixin that does not inherit a django Model. So the field check failed without these changes.