### PR TITLE
Added default autofield to the CabinetConfig

### DIFF
--- a/cabinet/apps.py
+++ b/cabinet/apps.py
@@ -3,5 +3,7 @@ from django.utils.translation import gettext_lazy as _
 
 
 class CabinetConfig(AppConfig):
+    default_auto_field = "django.db.models.AutoField"
+
     name = "cabinet"
     verbose_name = _("Cabinet media library")


### PR DESCRIPTION
Set the default autofield to AutoField. This fixes an issue where django
3.2 wants to add migrations to change the id fields of file and folder
to BigAutoField

This fixes #13 