### PR TITLE
Corrected version numbers in changelog.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Change log
 - Specified the default ``AutoField`` for django-cabinet to avoid migrations.
 - Added an additional safeguard against unhandleable images.
 - Fixed the ``default_app_config`` deprecation warning.
-- Raised the minimum versions of Python to 3.2 and Django to 3.8.
+- Raised the minimum versions of Python to 3.8 and Django to 3.2.
 
 
 `0.11`_ (2020-09-12)


### PR DESCRIPTION
The Python and Django version numbers were previously reversed.